### PR TITLE
Features/more naming convention extensions

### DIFF
--- a/Sqleze/Core/ReadArrayExtensions.cs
+++ b/Sqleze/Core/ReadArrayExtensions.cs
@@ -88,37 +88,21 @@ public static class ReadArrayExtensions
     }
 
 
-
     public static T[] ReadArray<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
         where T : notnull
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadArray<T>();
+        => scopedSqlezeParameterFactory.Command.ReadArray<T>();
 
     public static T?[] ReadArrayNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadArrayNullable<T?>();
+        => scopedSqlezeParameterFactory.Command.ReadArrayNullable<T?>();
 
-    public static ISqlezeReader ReadArray<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T[]>> action)
-    where T : notnull
-    {
-        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        sqlezeReader.ReadArray<T>(action);
+    public static ISqlezeReader ReadArray<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T[]>> action)
+    where T : notnull 
+        => scopedSqlezeParameterFactory.Command.ExecuteReader().ReadArray<T>(action);
 
-        return sqlezeReader;
-    }
-
-    public static ISqlezeReader ReadArrayNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?[]>> action)
-    {
-        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        sqlezeReader.ReadArrayNullable<T>(action);
-
-        return sqlezeReader;
-    }
-
-
-
+    public static ISqlezeReader ReadArrayNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T?[]>> action)
+        => scopedSqlezeParameterFactory.Command.ReadArrayNullable<T>(action);
 
 
     // async versions. Note we can't have the OUT parameter ones due to how async works.
@@ -221,77 +205,40 @@ public static class ReadArrayExtensions
     }
 
 
+    public static async Task<T[]> ReadArrayAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+        where T : notnull 
+        => await scopedSqlezeParameterFactory
+                .Command
+                .ReadArrayAsync<T>(cancellationToken)
+                .ConfigureAwait(false);
 
-
-
-
-    public static async Task<T[]> ReadArrayAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
-        where T : notnull
-    {
-        return await
-            (
-                await scopedSqlezeParameterFactory
-                    .Command
-                    .ExecuteReaderAsync(null, cancellationToken)
-                    .ConfigureAwait(false)
-            )
-            .ReadArrayAsync<T>(cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    public static async Task<T?[]> ReadArrayNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
-    {
-        return await
-            (
-                await scopedSqlezeParameterFactory
-                    .Command
-                    .ExecuteReaderAsync(null, cancellationToken)
-                    .ConfigureAwait(false)
-            )
-            .ReadArrayNullableAsync<T>(cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public static async Task<T?[]> ReadArrayNullableAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+        => await scopedSqlezeParameterFactory
+                .Command
+                .ReadArrayNullableAsync<T>(cancellationToken)
+                .ConfigureAwait(false);
 
     public static async Task<ISqlezeReader> ReadArrayAsync<T>(
         this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<T[]>> action,
         CancellationToken cancellationToken = default)
         where T : notnull
-    {
-        var reader = await scopedSqlezeParameterFactory
-            .Command
-            .ExecuteReaderAsync(null, cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader.ReadArrayAsync<T>(action, cancellationToken).ConfigureAwait(false);
-    }
+        => await scopedSqlezeParameterFactory
+                .Command
+                .ReadArrayAsync<T>(action, cancellationToken)
+                .ConfigureAwait(false);
 
     public static async Task<ISqlezeReader> ReadArrayNullableAsync<T>(
         this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<T?[]>> action,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory
-            .Command
-            .ExecuteReaderAsync(null, cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader.ReadArrayNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
-    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        => await scopedSqlezeParameterFactory
+                .Command
+                .ReadArrayNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
 
 
     public static async Task<ISqlezeReader> ReadArrayAsync<T>(

--- a/Sqleze/Core/ReadArrayExtensions.cs
+++ b/Sqleze/Core/ReadArrayExtensions.cs
@@ -87,6 +87,40 @@ public static class ReadArrayExtensions
         return sqlezeReader;
     }
 
+
+
+    public static T[] ReadArray<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        where T : notnull
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadArray<T>();
+
+    public static T?[] ReadArrayNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadArrayNullable<T?>();
+
+    public static ISqlezeReader ReadArray<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T[]>> action)
+    where T : notnull
+    {
+        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        sqlezeReader.ReadArray<T>(action);
+
+        return sqlezeReader;
+    }
+
+    public static ISqlezeReader ReadArrayNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?[]>> action)
+    {
+        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        sqlezeReader.ReadArrayNullable<T>(action);
+
+        return sqlezeReader;
+    }
+
+
+
+
+
     // async versions. Note we can't have the OUT parameter ones due to how async works.
 
     public static async Task<T[]> ReadArrayAsync<T>(this ISqlezeReader sqlezeReader, CancellationToken cancellationToken = default)
@@ -185,6 +219,79 @@ public static class ReadArrayExtensions
 
         return await reader.ReadArrayNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
     }
+
+
+
+
+
+
+    public static async Task<T[]> ReadArrayAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        return await
+            (
+                await scopedSqlezeParameterFactory
+                    .Command
+                    .ExecuteReaderAsync(null, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .ReadArrayAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<T?[]> ReadArrayNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
+    {
+        return await
+            (
+                await scopedSqlezeParameterFactory
+                    .Command
+                    .ExecuteReaderAsync(null, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .ReadArrayNullableAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<ISqlezeReader> ReadArrayAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T[]>> action,
+        CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        var reader = await scopedSqlezeParameterFactory
+            .Command
+            .ExecuteReaderAsync(null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader.ReadArrayAsync<T>(action, cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<ISqlezeReader> ReadArrayNullableAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T?[]>> action,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory
+            .Command
+            .ExecuteReaderAsync(null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader.ReadArrayNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
     public static async Task<ISqlezeReader> ReadArrayAsync<T>(

--- a/Sqleze/Core/ReadListExtensions.cs
+++ b/Sqleze/Core/ReadListExtensions.cs
@@ -88,40 +88,21 @@ public static class ReadListExtensions
         return sqlezeReader;
     }
 
-
-
     
     public static List<T> ReadList<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
         where T : notnull
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadList<T>();
+        => scopedSqlezeParameterFactory.Command.ReadList<T>();
 
     public static List<T?> ReadListNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadListNullable<T?>();
+        => scopedSqlezeParameterFactory.Command.ReadListNullable<T?>();
 
 
     public static ISqlezeReader ReadList<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<List<T>>> action)
         where T : notnull
-    {
-        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        sqlezeReader.ReadList<T>(action);
-
-        return sqlezeReader;
-    }
+        => scopedSqlezeParameterFactory.Command.ReadList<T>(action);
 
     public static ISqlezeReader ReadListNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<List<T?>>> action)
-    {
-        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        sqlezeReader.ReadListNullable<T>(action);
-
-        return sqlezeReader;
-    }
-
-
-
+        => scopedSqlezeParameterFactory.Command.ReadListNullable<T>(action);
 
 
     // async versions. Note we can't have the OUT parameter ones due to how async works.
@@ -223,60 +204,41 @@ public static class ReadListExtensions
         return await reader.ReadListNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
     }
 
-
-
-    public static async Task<List<T>> ReadListAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
-        where T : notnull
-    {
-        return await
-            (
-                await scopedSqlezeParameterFactory.Command
-                    .ExecuteReaderAsync(null, cancellationToken)
-                    .ConfigureAwait(false)
-            )
+    public static async Task<List<T>> ReadListAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+        where T : notnull 
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadListAsync<T>(cancellationToken)
             .ConfigureAwait(false);
-    }
 
-    public static async Task<List<T?>> ReadListNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
-    {
-        return await
-            (
-                await scopedSqlezeParameterFactory.Command
-                    .ExecuteReaderAsync(null, cancellationToken)
-                    .ConfigureAwait(false)
-            )
+    public static async Task<List<T?>> ReadListNullableAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadListNullableAsync<T>(cancellationToken)
             .ConfigureAwait(false);
-    }
 
     public static async Task<ISqlezeReader> ReadListAsync<T>(
         this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<List<T>>> action,
         CancellationToken cancellationToken = default)
         where T : notnull
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(null, cancellationToken)
+        => await scopedSqlezeParameterFactory
+            .Command
+            .ReadListAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
-
-        return await reader.ReadListAsync<T>(action, cancellationToken).ConfigureAwait(false);
-    }
 
     public static async Task<ISqlezeReader> ReadListNullableAsync<T>(
         this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<List<T?>>> action,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(null, cancellationToken)
+        => await scopedSqlezeParameterFactory
+            .Command
+            .ReadListNullableAsync<T?>(action, cancellationToken)
             .ConfigureAwait(false);
-
-        return await reader.ReadListNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
-    }
-
-
-
 
     public static async Task<ISqlezeReader> ReadListAsync<T>(
         this Task<ISqlezeReader> sqlezeReaderTask,

--- a/Sqleze/Core/ReadListExtensions.cs
+++ b/Sqleze/Core/ReadListExtensions.cs
@@ -89,6 +89,41 @@ public static class ReadListExtensions
     }
 
 
+
+    
+    public static List<T> ReadList<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        where T : notnull
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadList<T>();
+
+    public static List<T?> ReadListNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadListNullable<T?>();
+
+
+    public static ISqlezeReader ReadList<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<List<T>>> action)
+        where T : notnull
+    {
+        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        sqlezeReader.ReadList<T>(action);
+
+        return sqlezeReader;
+    }
+
+    public static ISqlezeReader ReadListNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<List<T?>>> action)
+    {
+        var sqlezeReader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        sqlezeReader.ReadListNullable<T>(action);
+
+        return sqlezeReader;
+    }
+
+
+
+
+
     // async versions. Note we can't have the OUT parameter ones due to how async works.
 
     public static async Task<List<T>> ReadListAsync<T>(this ISqlezeReader sqlezeReader, CancellationToken cancellationToken = default)
@@ -187,6 +222,60 @@ public static class ReadListExtensions
 
         return await reader.ReadListNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
     }
+
+
+
+    public static async Task<List<T>> ReadListAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        return await
+            (
+                await scopedSqlezeParameterFactory.Command
+                    .ExecuteReaderAsync(null, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .ReadListAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<List<T?>> ReadListNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, CancellationToken cancellationToken = default)
+    {
+        return await
+            (
+                await scopedSqlezeParameterFactory.Command
+                    .ExecuteReaderAsync(null, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            .ReadListNullableAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<ISqlezeReader> ReadListAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<List<T>>> action,
+        CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader.ReadListAsync<T>(action, cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<ISqlezeReader> ReadListNullableAsync<T>(
+        this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<List<T?>>> action,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader.ReadListNullableAsync<T?>(action, cancellationToken).ConfigureAwait(false);
+    }
+
+
 
 
     public static async Task<ISqlezeReader> ReadListAsync<T>(

--- a/Sqleze/Core/ReadSingleExtensions.cs
+++ b/Sqleze/Core/ReadSingleExtensions.cs
@@ -117,48 +117,25 @@ public static class ReadSingleExtensions
         return reader.ReadSingleOrDefault<T?>(action);
     }
 
-
-
     public static T ReadSingle<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
         where T : notnull
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadSingle<T>();
+        => scopedSqlezeParameterFactory.Command.ReadSingle<T>();
 
     public static T? ReadSingleNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadSingleNullable<T?>();
+        => scopedSqlezeParameterFactory.Command.ReadSingleNullable<T?>();
 
     public static T? ReadSingleOrDefault<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
-        => scopedSqlezeParameterFactory.Command
-            .ExecuteReader()
-            .ReadSingleOrDefault<T?>();
-
-
+        => scopedSqlezeParameterFactory.Command.ReadSingleOrDefault<T?>();
 
     public static ISqlezeReader ReadSingle<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T>> action)
         where T : notnull
-    {
-        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        return reader.ReadSingle<T>(action);
-    }
+        => scopedSqlezeParameterFactory.Command.ReadSingle<T>(action);
 
     public static ISqlezeReader ReadSingleNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?>> action)
-    {
-        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        return reader.ReadSingleNullable<T?>(action);
-    }
+        => scopedSqlezeParameterFactory.Command.ReadSingleNullable<T?>(action);
 
     public static ISqlezeReader ReadSingleOrDefault<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?>> action)
-    {
-        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
-        return reader.ReadSingleOrDefault<T?>(action);
-    }
-
-
-
-
+        => scopedSqlezeParameterFactory.Command.ReadSingleOrDefault<T?>(action);
 
     public static async Task<T> ReadSingleAsync<T>(this ISqlezeReader sqlezeReader,
         CancellationToken cancellationToken = default)
@@ -349,105 +326,51 @@ public static class ReadSingleExtensions
             .ReadSingleOrDefaultAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
     }
-
-
-
-
-
-
-
-
-    
+        
     public static async Task<T> ReadSingleAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         CancellationToken cancellationToken = default)
         where T : notnull
-    {
-        var reader = await scopedSqlezeParameterFactory.Command 
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleAsync<T>(cancellationToken)
             .ConfigureAwait(false);
-    }
+    
     public static async Task<T?> ReadSingleNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleNullableAsync<T>(cancellationToken)
             .ConfigureAwait(false);
-    }
 
     public static async Task<T?> ReadSingleOrDefaultAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleOrDefaultAsync<T>(cancellationToken)
             .ConfigureAwait(false);
-    }
-
-
-
-
 
     public static async Task<ISqlezeReader> ReadSingleAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<T>> action,
         CancellationToken cancellationToken = default)
         where T : notnull
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
-    }
+
     public static async Task<ISqlezeReader> ReadSingleNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<T?>> action,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleNullableAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
-    }
 
     public static async Task<ISqlezeReader> ReadSingleOrDefaultAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
         Expression<Func<T?>> action,
         CancellationToken cancellationToken = default)
-    {
-        var reader = await scopedSqlezeParameterFactory.Command
-            .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await reader
+        => await scopedSqlezeParameterFactory
+            .Command
             .ReadSingleOrDefaultAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
-    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/Sqleze/Core/ReadSingleExtensions.cs
+++ b/Sqleze/Core/ReadSingleExtensions.cs
@@ -119,6 +119,46 @@ public static class ReadSingleExtensions
 
 
 
+    public static T ReadSingle<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        where T : notnull
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadSingle<T>();
+
+    public static T? ReadSingleNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadSingleNullable<T?>();
+
+    public static T? ReadSingleOrDefault<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        => scopedSqlezeParameterFactory.Command
+            .ExecuteReader()
+            .ReadSingleOrDefault<T?>();
+
+
+
+    public static ISqlezeReader ReadSingle<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T>> action)
+        where T : notnull
+    {
+        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        return reader.ReadSingle<T>(action);
+    }
+
+    public static ISqlezeReader ReadSingleNullable<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?>> action)
+    {
+        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        return reader.ReadSingleNullable<T?>(action);
+    }
+
+    public static ISqlezeReader ReadSingleOrDefault<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory, Expression<Func<T?>> action)
+    {
+        var reader = scopedSqlezeParameterFactory.Command.ExecuteReader();
+        return reader.ReadSingleOrDefault<T?>(action);
+    }
+
+
+
+
 
     public static async Task<T> ReadSingleAsync<T>(this ISqlezeReader sqlezeReader,
         CancellationToken cancellationToken = default)
@@ -309,6 +349,103 @@ public static class ReadSingleExtensions
             .ReadSingleOrDefaultAsync<T>(action, cancellationToken)
             .ConfigureAwait(false);
     }
+
+
+
+
+
+
+
+
+    
+    public static async Task<T> ReadSingleAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        var reader = await scopedSqlezeParameterFactory.Command 
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+    public static async Task<T?> ReadSingleNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleNullableAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<T?> ReadSingleOrDefaultAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleOrDefaultAsync<T>(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+
+
+
+
+    public static async Task<ISqlezeReader> ReadSingleAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T>> action,
+        CancellationToken cancellationToken = default)
+        where T : notnull
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleAsync<T>(action, cancellationToken)
+            .ConfigureAwait(false);
+    }
+    public static async Task<ISqlezeReader> ReadSingleNullableAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T?>> action,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleNullableAsync<T>(action, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<ISqlezeReader> ReadSingleOrDefaultAsync<T>(this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory,
+        Expression<Func<T?>> action,
+        CancellationToken cancellationToken = default)
+    {
+        var reader = await scopedSqlezeParameterFactory.Command
+            .ExecuteReaderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await reader
+            .ReadSingleOrDefaultAsync<T>(action, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/Sqleze/Core/RegistrationExtensions.cs
+++ b/Sqleze/Core/RegistrationExtensions.cs
@@ -33,7 +33,7 @@ public static class CoreRegistrationExtensions
         registrator.Register(typeof(IGenericResolver<>), typeof(GenericResolver<>));
         registrator.Register(typeof(IMultiResolver<,>), typeof(MultiResolver<,>));
 
-        registrator.Register<ISqlezeBuilder, SqlezeConnectionBuilder>(
+        registrator.Register<ISqlezeBuilder, SqlezeBuilder>(
             Reuse.ScopedOrSingleton,
             setup: Setup.With(asResolutionCall: true));
 

--- a/Sqleze/Core/SqlezeBuilder.cs
+++ b/Sqleze/Core/SqlezeBuilder.cs
@@ -2,12 +2,12 @@
 
 namespace Sqleze;
 
-public class SqlezeConnectionBuilder : ISqlezeBuilder
+public class SqlezeBuilder : ISqlezeBuilder
 {
     private readonly IResolverContext factoryScope;
     private readonly Func<ISqleze> newSqlezeConnectionFactory;
 
-    public SqlezeConnectionBuilder(IResolverContext scope,
+    public SqlezeBuilder(IResolverContext scope,
         Func<ISqleze> newSqlezeConnectionFactory)
     {
         this.factoryScope = scope;

--- a/Sqleze/Metadata/TableTypeMetadataQuery.cs
+++ b/Sqleze/Metadata/TableTypeMetadataQuery.cs
@@ -18,14 +18,14 @@ namespace Sqleze.Metadata
     public class TableTypeMetadataQuery : ITableTypeMetadataQuery
     {
         private readonly IConnectionStringProvider connectionStringProvider;
-        private readonly ISqlezeBuilder sqlezeConnectionBuilder;
+        private readonly ISqlezeBuilder sqlezeBuilder;
 
         public TableTypeMetadataQuery(
             IConnectionStringProvider connectionStringProvider,
-            ISqlezeBuilder sqlezeConnectionBuilder)
+            ISqlezeBuilder sqlezeBuilder)
         {
             this.connectionStringProvider = connectionStringProvider;
-            this.sqlezeConnectionBuilder = sqlezeConnectionBuilder;
+            this.sqlezeBuilder = sqlezeBuilder;
         }
 
 
@@ -59,7 +59,7 @@ namespace Sqleze.Metadata
 
             // Go back to the root container and reconfigure in a known state.
             // Only special thing we want is the connection string.
-            var connectionFactory = sqlezeConnectionBuilder
+            var connectionFactory = sqlezeBuilder
                 .WithConnectionString(connStr)
                 .WithCamelUnderscoreNaming()
                 .Build();

--- a/Sqleze/Metadata/TableTypeMetadataQuery.cs
+++ b/Sqleze/Metadata/TableTypeMetadataQuery.cs
@@ -17,24 +17,19 @@ namespace Sqleze.Metadata
 
     public class TableTypeMetadataQuery : ITableTypeMetadataQuery
     {
-        private readonly IConnectionStringProvider connectionStringProvider;
-        private readonly ISqlezeBuilder sqlezeBuilder;
+        private readonly ISqleze sqleze;
 
         public TableTypeMetadataQuery(
-            IConnectionStringProvider connectionStringProvider,
-            ISqlezeBuilder sqlezeBuilder)
+            ISqleze sqleze)
         {
-            this.connectionStringProvider = connectionStringProvider;
-            this.sqlezeBuilder = sqlezeBuilder;
+            this.sqleze = sqleze;
         }
 
 
         public async Task<IReadOnlyList<TableTypeColumnDefinition>> QueryAsync(string sqlTypeName,
             CancellationToken cancellationToken = default)
         {
-            var factory = setupConnectionFactory();
-
-            using var conn = factory.Connect();
+            using var conn = sqleze.Connect();
             var command = buildCommand(conn, sqlTypeName);
 
             return (await command.ReadListAsync<TableTypeColumnDefinition>(cancellationToken).ConfigureAwait(false))
@@ -43,33 +38,16 @@ namespace Sqleze.Metadata
 
         public IReadOnlyList<TableTypeColumnDefinition> Query(string sqlTypeName)
         {
-            var factory = setupConnectionFactory();
-
-            using var conn = factory.Connect();
+            using var conn = sqleze.Connect();
             var command = buildCommand(conn, sqlTypeName);
 
             return command.ReadList<TableTypeColumnDefinition>()
                 .AsReadOnly();
         }
 
-        private ISqleze setupConnectionFactory()
-        {
-            // Pull out the connection string verbatim.
-            var connStr = connectionStringProvider.GetConnectionString();
-
-            // Go back to the root container and reconfigure in a known state.
-            // Only special thing we want is the connection string.
-            var connectionFactory = sqlezeBuilder
-                .WithConnectionString(connStr)
-                .WithCamelUnderscoreNaming()
-                .Build();
-
-            return connectionFactory;
-        }
-
         private static ISqlezeCommand buildCommand(ISqlezeConnection conn, string sqlTypeName)
         {
-            var command = conn.Sql(@"
+            var command = conn.WithCamelUnderscoreNaming().Sql(@"
 
 SELECT	column_name = sycol.name,
         column_ordinal = ROW_NUMBER() OVER (ORDER BY sycol.column_id) - 1,

--- a/Sqleze/NamingConventions/NamingConventionExtensions.cs
+++ b/Sqleze/NamingConventions/NamingConventionExtensions.cs
@@ -44,10 +44,16 @@ namespace Sqleze
         }
 
         public static ISqlezeRowsetBuilder WithCamelUnderscoreNaming(
-            this ISqlezeReader sqlezeReader
-        )
+            this ISqlezeReader sqlezeReader)
         {
             return sqlezeReader.With<CamelUnderscoreNamingConventionRoot>((_, _) => { });
+        }
+
+        
+        public static ISqlezeReaderBuilder WithCamelUnderscoreNaming(
+            this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        {
+            return scopedSqlezeParameterFactory.Command.With<CamelUnderscoreNamingConventionRoot>((_, _) => { });
         }
 
         public static ISqlezeBuilder WithNeutralNaming(
@@ -76,19 +82,22 @@ namespace Sqleze
             return sqlezeParameter.Command.With<NeutralNamingConventionRoot>((_, _) => { });
         }
 
-        public static ISqlezeReaderBuilder WithNeutralNaming(
+        public static ISqlezeParameterBuilder WithNeutralNaming(
             this ISqlezeParameterCollection sqlezeParameterCollection)
         {
-            return sqlezeParameterCollection.Command.With<NeutralNamingConventionRoot>((_, _) => { });
+            return sqlezeParameterCollection.With<NeutralNamingConventionRoot>((_, _) => { });
         }
 
         public static ISqlezeRowsetBuilder WithNeutralNaming(
-            this ISqlezeReader sqlezeReader
-        )
+            this ISqlezeReader sqlezeReader)
         {
             return sqlezeReader.With<NeutralNamingConventionRoot>((_, _) => { });
         }
 
-
+        public static ISqlezeReaderBuilder WithNeutralNaming(
+            this IScopedSqlezeParameterFactory scopedSqlezeParameterFactory)
+        {
+            return scopedSqlezeParameterFactory.Command.With<NeutralNamingConventionRoot>((_, _) => { });
+        }
     }
 }


### PR DESCRIPTION
Add extensions to choose naming convention when within command scope or parameter scope.
Amended how the metadata for stored procs and table types is queried so that it will now pick up any additional connection details such as the AccessToken.