### PR TITLE
#16 Add support for DateOnly / TimeOnly within SqlDataRecord

### DIFF
--- a/Sqleze.Tests/Integration/TableValuedParameterTests.cs
+++ b/Sqleze.Tests/Integration/TableValuedParameterTests.cs
@@ -3,9 +3,11 @@ using Shouldly;
 using Sqleze;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnitTestCoder.Shouldly.Gen;
 
 namespace Sqleze.Tests.Integration
 {
@@ -252,6 +254,134 @@ namespace Sqleze.Tests.Integration
                 new byte[] { 0x01, 0x02 },
                 new byte[] { 0x03, 0x04 }
             });
+        }
+
+        [TestMethod]
+        public void TableValuedParameterKnownTypeDateOnly()
+        {
+            using var conn = OpenBuilder()
+                .WithTableTypeFor<DateOnly>("dbo.tt_date_vals")
+                .Connect();
+
+            var arg = new List<DateOnly>() 
+            { 
+                new DateOnly(2024,01,01),
+                new DateOnly(2022,12,25),
+            }.AsEnumerable();
+
+            var result = conn.Sql("SELECT val FROM @arg")
+                .Parameters.Set(() => arg)
+                .ReadList<DateOnly>();
+
+            result.ShouldBe(new List<DateOnly>() 
+            { 
+                new DateOnly(2024,01,01),
+                new DateOnly(2022,12,25),
+            });
+        }
+
+        [TestMethod]
+        public void TableValuedParameterKnownTypeDateOnlyNullable()
+        {
+            using var conn = OpenBuilder()
+                .WithTableTypeFor<DateOnly?>("dbo.tt_date_nullable_vals")
+                .Connect();
+
+            var arg = new List<DateOnly?>() 
+            { 
+                new DateOnly(2024,01,01),
+                null,
+                new DateOnly(2022,12,25),
+            }.AsEnumerable();
+
+            var result = conn.Sql("SELECT val FROM @arg")
+                .Parameters.Set(() => arg)
+                .ReadListNullable<DateOnly?>();
+
+            result.ShouldBe(new List<DateOnly?>() 
+            { 
+                new DateOnly(2024,01,01),
+                null,
+                new DateOnly(2022,12,25),
+            });
+        }
+        
+        [TestMethod]
+        public void TableValuedParameterKnownTypeTimeOnly()
+        {
+            using var conn = OpenBuilder()
+                .WithTableTypeFor<TimeOnly>("dbo.tt_time_vals")
+                .Connect();
+
+            var arg = new List<TimeOnly>() 
+            { 
+                new TimeOnly(23,01,01),
+                new TimeOnly(13,12,25),
+            }.AsEnumerable();
+
+            var result = conn.Sql("SELECT val FROM @arg")
+                .Parameters.Set(() => arg)
+                .ReadList<TimeOnly>();
+
+            result.ShouldBe(new List<TimeOnly>() 
+            { 
+                new TimeOnly(23,01,01),
+                new TimeOnly(13,12,25),
+            });
+        }
+
+        [TestMethod]
+        public void TableValuedParameterKnownTypeTimeOnlyNullable()
+        {
+            using var conn = OpenBuilder()
+                .WithTableTypeFor<TimeOnly?>("dbo.tt_time_nullable_vals")
+                .Connect();
+
+            var arg = new List<TimeOnly?>() 
+            { 
+                new TimeOnly(23,01,01),
+                null,
+                new TimeOnly(13,12,25),
+            }.AsEnumerable();
+
+            var result = conn.Sql("SELECT val FROM @arg")
+                .Parameters.Set(() => arg)
+                .ReadListNullable<TimeOnly?>();
+
+            result.ShouldBe(new List<TimeOnly?>() 
+            { 
+                new TimeOnly(23,01,01),
+                null,
+                new TimeOnly(13,12,25),
+            });
+        }
+
+        
+        [TestMethod]
+        public void TableValuedParameterKnownTypeDateTimeOffset()
+        {
+            using var conn = OpenBuilder()
+                .WithTableTypeFor<DateTimeOffset>("dbo.tt_datetimeoffset_7_vals")
+                .Connect();
+
+            var arg = new List<DateTimeOffset>() 
+            { 
+                DateTimeOffset.Parse("2024-07-23T15:57:54.7842948+01:00"),
+                DateTimeOffset.Parse("2023-07-23T15:57:54.7842947+02:00"),
+            }.AsEnumerable();
+
+            var result = conn.Sql("SELECT val FROM @arg")
+                .Parameters.Set(() => arg)
+                .ReadList<DateTimeOffset>();
+
+            //ShouldlyTest.Gen(result,nameof(result));
+
+            {
+                result.ShouldNotBeNull();
+                result.Count().ShouldBe(2);
+                result[0].ShouldBe(DateTimeOffset.Parse("2024-07-23T15:57:54.7842948+01:00"));
+                result[1].ShouldBe(DateTimeOffset.Parse("2023-07-23T15:57:54.7842947+02:00"));
+            }
         }
 
         private class ValClass

--- a/Sqleze/TableValuedParameters/RecordSetValue.cs
+++ b/Sqleze/TableValuedParameters/RecordSetValue.cs
@@ -13,3 +13,56 @@ public class RecordSetValue<T> : IRecordSetValue<T>
         sqlDataRecord.SetValue(columnIndex, val);
     }
 }
+
+
+public class RecordSetValueDateOnly : IRecordSetValue<DateOnly>
+{
+    public void SetValue(MSS.SqlDataRecord sqlDataRecord, int columnIndex, object val)
+    {
+        DateOnly dateOnly = (DateOnly)val;
+        DateTime dateTime = dateOnly.ToDateTime(TimeOnly.MinValue);
+        sqlDataRecord.SetValue(columnIndex, dateTime);
+    }
+}
+
+public class RecordSetValueDateOnlyNullable : IRecordSetValue<DateOnly?>
+{
+    public void SetValue(MSS.SqlDataRecord sqlDataRecord, int columnIndex, object val)
+    {
+        if(val == null)
+        {
+            sqlDataRecord.SetDBNull(columnIndex);
+        }
+        else
+        {
+            DateOnly? dateOnly = (DateOnly?)val;
+            DateTime dateTime = dateOnly.Value.ToDateTime(TimeOnly.MinValue);
+            sqlDataRecord.SetValue(columnIndex, dateTime);
+        }
+    }
+}
+
+public class RecordSetValueTimeOnly : IRecordSetValue<TimeOnly>
+{
+    public void SetValue(MSS.SqlDataRecord sqlDataRecord, int columnIndex, object val)
+    {
+        TimeOnly timeOnly = (TimeOnly)val;
+        sqlDataRecord.SetValue(columnIndex, timeOnly.ToTimeSpan());
+    }
+}
+
+public class RecordSetValueTimeOnlyNullable : IRecordSetValue<TimeOnly?>
+{
+    public void SetValue(MSS.SqlDataRecord sqlDataRecord, int columnIndex, object val)
+    {
+        if(val == null)
+        {
+            sqlDataRecord.SetDBNull(columnIndex);
+        }
+        else
+        {
+            TimeOnly? timeOnly = (TimeOnly?)val;
+            sqlDataRecord.SetValue(columnIndex, timeOnly.Value.ToTimeSpan());
+        }
+    }
+}

--- a/Sqleze/TableValuedParameters/TableTypeColumnToSqlMetaDataConverter.cs
+++ b/Sqleze/TableValuedParameters/TableTypeColumnToSqlMetaDataConverter.cs
@@ -38,11 +38,23 @@ namespace Sqleze.TableValuedParameters
 
             // Has a precision OR scale, pass them both
             if (sqlDbType.HasPrecision() || sqlDbType.HasScale())
+            {
+                byte precision =
+                    sqlDbType.HasPrecision()
+                    ? (byte)columnDef.Precision
+                    : (byte)0;
+
+                byte scale =
+                    sqlDbType.HasScale()
+                    ? (byte)columnDef.Scale
+                    : (byte)0;
+
                 return sqlMetaDataFactory.New(
                     columnDef.ColumnName,
                     sqlDbType,
-                    (byte)columnDef.Precision,
-                    (byte)columnDef.Scale);
+                    precision,
+                    scale);
+            }
 
             // No size, precision or scale.
             return sqlMetaDataFactory.New(

--- a/Sqleze/TableValuedParameters/TableValuedParameterRegistrationExtensions.cs
+++ b/Sqleze/TableValuedParameters/TableValuedParameterRegistrationExtensions.cs
@@ -42,6 +42,10 @@ public static class TableValuedParameterRegistrationExtensions
         registrator.Register<IRecordSetValue<SqlSingle>, RecordSetSqlValueSqlSingle>(Reuse.Singleton);
         registrator.Register<IRecordSetValue<SqlString>, RecordSetSqlValueSqlString>(Reuse.Singleton);
         registrator.Register<IRecordSetValue<SqlXml>, RecordSetSqlValueSqlXml>(Reuse.Singleton);
+        registrator.Register<IRecordSetValue<DateOnly>, RecordSetValueDateOnly>(Reuse.Singleton);
+        registrator.Register<IRecordSetValue<DateOnly?>, RecordSetValueDateOnlyNullable>(Reuse.Singleton);
+        registrator.Register<IRecordSetValue<TimeOnly>, RecordSetValueTimeOnly>(Reuse.Singleton);
+        registrator.Register<IRecordSetValue<TimeOnly?>, RecordSetValueTimeOnlyNullable>(Reuse.Singleton);
     }
 
 
@@ -85,6 +89,12 @@ public static class TableValuedParameterRegistrationExtensions
         registrator.Register<ISqlDataRecordMapper<Guid?>,           SqlDataRecordScalarMapper<Guid?>>(Reuse.Singleton);
         registrator.Register<ISqlDataRecordMapper<TimeSpan>,        SqlDataRecordScalarMapper<TimeSpan>>(Reuse.Singleton);
         registrator.Register<ISqlDataRecordMapper<TimeSpan?>,       SqlDataRecordScalarMapper<TimeSpan?>>(Reuse.Singleton);
+        registrator.Register<ISqlDataRecordMapper<DateOnly>,        SqlDataRecordScalarMapper<DateOnly>>(Reuse.Singleton);
+        registrator.Register<ISqlDataRecordMapper<DateOnly?>,       SqlDataRecordScalarMapper<DateOnly?>>(Reuse.Singleton);
+        registrator.Register<ISqlDataRecordMapper<TimeOnly>,        SqlDataRecordScalarMapper<TimeOnly>>(Reuse.Singleton);
+        registrator.Register<ISqlDataRecordMapper<TimeOnly?>,       SqlDataRecordScalarMapper<TimeOnly?>>(Reuse.Singleton);
+
+
         registrator.Register<ISqlDataRecordMapper<SqlBinary>,       SqlDataRecordScalarMapper<SqlBinary>>(Reuse.Singleton);
         registrator.Register<ISqlDataRecordMapper<SqlBinary?>,      SqlDataRecordScalarMapper<SqlBinary?>>(Reuse.Singleton);
         registrator.Register<ISqlDataRecordMapper<SqlBoolean>,      SqlDataRecordScalarMapper<SqlBoolean>>(Reuse.Singleton);

--- a/TestCommon/DbSchema/CreateTestSqlDatabase.sql
+++ b/TestCommon/DbSchema/CreateTestSqlDatabase.sql
@@ -160,6 +160,33 @@ CREATE TYPE [test].[udt_table] AS TABLE(
 )
 GO
 
+CREATE TYPE dbo.tt_date_vals
+AS TABLE (val date NULL)
+GO
+
+CREATE TYPE dbo.tt_time_vals
+AS TABLE (val time NULL)
+GO
+
+CREATE TYPE dbo.tt_date_nullable_vals AS TABLE
+(
+    val date NULL
+);
+GO
+
+CREATE TYPE dbo.tt_time_nullable_vals AS TABLE
+(
+    val time NULL
+);
+GO
+
+CREATE TYPE dbo.tt_datetimeoffset_7_vals
+AS TABLE
+(
+    val datetimeoffset(7)
+)
+GO
+
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON


### PR DESCRIPTION
Fix issue where DateOnly / TimeOnly caused type mismatches when passing into SqlDataRecord table-valued parameters.